### PR TITLE
remove unnecessary IOBuffer construction

### DIFF
--- a/src/StringBuilders.jl
+++ b/src/StringBuilders.jl
@@ -20,7 +20,6 @@ end
 
 function Base.append!(sb::StringBuilder, s::AbstractString)
     if !isnull(sb.as_string)
-        sb.buffer = IOBuffer()
         print(sb.buffer, get(sb.as_string))
         sb.as_string = Nullable{String}()
     end


### PR DESCRIPTION
Only one IOBuffer object needs to be created. This is follows from the documented behavior of `take!`.
```
take!(b::IOBuffer)
Obtain the contents of an IOBuffer as an array, without copying. Afterwards,
the IOBuffer is reset to its initial state.
```